### PR TITLE
Update outp_pkgs.rst

### DIFF
--- a/doc/outp_pkgs/outp_pkgs.rst
+++ b/doc/outp_pkgs/outp_pkgs.rst
@@ -215,6 +215,8 @@ grid-attribute information. The :varlink:`gdiag` array is described in :numref:`
    +-----------+-----------------------+-----------------------------------------------------+
    |           | :math:`\rightarrow` V | V-vector component diagnostic                       |
    +-----------+-----------------------+-----------------------------------------------------+
+   |           | :math:`\rightarrow` W | W-vector component diagnostic                       |
+   +-----------+-----------------------+-----------------------------------------------------+
    | parse(2)  | :math:`\rightarrow` U | C-grid U-point                                      |
    +-----------+-----------------------+-----------------------------------------------------+
    |           | :math:`\rightarrow` V | C-grid V-point                                      |
@@ -269,7 +271,11 @@ grid-attribute information. The :varlink:`gdiag` array is described in :numref:`
 As an example, consider a diagnostic whose associated :varlink:`gdiag`
 parameter is equal to ``UUR     MR``. From :varlink:`gdiag` we can determine
 that this diagnostic is a U-vector component located at the C-grid U-point,
-model mid-level (M) with Nr levels (last R).
+model mid-level (M) with Nr levels (last R). Another example is a
+diagnostic whose :varlink:`gdiag` parameter of
+``WM     LR``. From :varlink:`gdiag` we determine this diagnostic 
+is a W-vector component located at the C-grid W-point, "top" of the grid cell (L)
+with Nr levels (last R).
 
 In this way, each diagnostic in the model has its attributes (i.e., vector
 or scalar, C-grid location, etc.) defined internally. The output


### PR DESCRIPTION

## What changes does this PR introduce?

Docs update

## What is the current behaviour? 

The documentation for the 'diag codes' does not include an entry for 'W' point. Many diagnostics use the 'W' code (like KPPg_TH) and the meaning of the 'W' code was not defined.

## What is the new behaviour 

Added row in the diagnostics "codes" table for 'W' points. There were codes for 'S', 'U', and 'V' but not 'W'.   Also added another example for the diag code: "WM LR", for 'w' point, 'center', 'top', and 'Nr' vertical levels.

## Does this PR introduce a breaking change? 
no

## Other information:


## Suggested addition to `tag-index`
Added row in the diagnostics "codes" table for 'W' points. 